### PR TITLE
angular-io-quickstart to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: node-http
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7
+- name: angular-io-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.5


### PR DESCRIPTION
Promote angular-io-quickstart to version 0.0.5