### PR TITLE
angular-io-quickstart to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 0.0.8
 - name: angular-io-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.6
+  version: 0.0.7


### PR DESCRIPTION
Promote angular-io-quickstart to version 0.0.7